### PR TITLE
fix : 댓글 타입 TEXT로 변경, 글자 수 1000자 제한

### DIFF
--- a/src/main/java/swyp/hobbi/swyphobbiback/comment/domain/Comment.java
+++ b/src/main/java/swyp/hobbi/swyphobbiback/comment/domain/Comment.java
@@ -1,6 +1,7 @@
 package swyp.hobbi.swyphobbiback.comment.domain;
 
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Size;
 import lombok.*;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
@@ -31,6 +32,10 @@ public class Comment {
     private Post post;
 
     private Long parentCommentId;
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    @Size(max = 1000)
     private String commentContent;
     private Boolean deleted;
 


### PR DESCRIPTION
*** 변경 사항 ***
1. 댓글의 타입을 TEXT로 변경하였습니다.
2. 글자 수를 1000자로 제한하였습니다.